### PR TITLE
Updated sequlize. Fix promise chain name for bluebird 2.9.34

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -4,9 +4,9 @@ Generates a DocSet from JSDoc documentation. This DocSet can be used with the Da
 
 ## Configuration
 
-```
+```javascript
 {
-  "docSetRoot": "/path/to/dir",
+  "docSetRoot": "/path/to/docset/output",
   "docSetName": "MyDocSetJs",
   "docSetIdentifier": "MyDocSet",
   "docSetPlatformFamily": "MyDocSet",
@@ -14,3 +14,24 @@ Generates a DocSet from JSDoc documentation. This DocSet can be used with the Da
   "documentation": "/path/to/jsdoc/output"
 }
 ```
+
+## Usage
+
+```javascript
+var JsdocDocsetGenerator = require('jsdoc-docset-generator'),
+
+var generator = new JsdocDocsetGenerator(
+    {
+      'documentation': '/path/to/jsdoc/output',
+      'docSetRoot': '/path/to/docset/output',
+      'docSetName': 'MyDocSetJs',
+      'docSetIdentifier': 'MyDocSet',
+      'docSetPlatformFamily': 'MyDocSet',
+      'icon': '/path/to/my/icon.png'
+    });
+
+generator
+    .populate(require('/path/to/docset.json'));
+```
+
+* `docset.json` can be generated from [jsdoc-dash-template](https://github.com/theasta/jsdoc-dash-template)

--- a/lib/docset-generator.js
+++ b/lib/docset-generator.js
@@ -144,21 +144,19 @@ DocSetGenerator.prototype.populate = function (entries) {
 
     this.sequelize
         .sync({ force: true })
-        .complete(function(err) {
-            if (err) {
-                deferred.reject(err);
-                throw err;
-            } else {
-                SearchItem.bulkCreate(entries)
-                    .error(function (err) {
-                        deferred.reject(err);
-                    })
-                    .success(function() {
-                        deferred.resolve();
-                    });
-
-            }
-        }.bind(this));
+        .then(function(err) {
+            SearchItem.bulkCreate(entries)
+                .catch(function (err) {
+                    deferred.reject(err);
+                })
+                .then(function() {
+                    deferred.resolve();
+                });
+        })
+        .catch(function(err) {
+            deferred.reject(err);
+            throw err;
+        });
 
     return deferred.promise;
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "extended-fs": "^0.3.3",
     "lodash-template-stream": "^1.0.0",
     "q": "^1.1.1",
-    "sequelize": "^2.0.0-rc2",
+    "sequelize": "^3.6.0",
     "sqlite3": "^3.0.2"
   },
   "scripts": {


### PR DESCRIPTION
`bluebird`, which `sequelize` depends on, has updated their promise api.
